### PR TITLE
Use idiomatic Ember (for fastboot compat)

### DIFF
--- a/addon/components/share-buttons.js
+++ b/addon/components/share-buttons.js
@@ -1,261 +1,124 @@
 import Ember from 'ember';
-import defaultConfig from '../utils/share-config';
-import _ from 'lodash/lodash';
 import template from '../templates/components/share-buttons';
+import $ from 'jquery';
 
-const { computed, $ } = Ember;
-const { readOnly } = computed;
-const capitalize = Ember.String.capitalize;
+const defaultNetworks = [
+  'pinterest',
+  'twitter',
+  'facebook',
+  'whatsapp',
+  'googlePlus',
+  'reddit',
+  'linkedin',
+  'email'
+];
 
 export default Ember.Component.extend({
   classNames: ['share-buttons'],
   layout: template,
-  enabledNetworks: readOnly('shareConfig.ui.enabledNetworks'),
-  flyouts: readOnly('shareConfig.ui.flyout'),
-  config: {},
+  config: null,
+  tagName: 'ul',
+
+  didReceiveAttrs() {
+    let config = this.get('config');
+    let networks;
+    if (config && config.networks) {
+      networks = config.networks.map(expandNetworkConfig)
+        .filter(n => defaultNetworks.indexOf(n.name) !== -1);
+    } else {
+      networks = defaultNetworks.map(expandNetworkConfig);
+    }
+    this.set('networks', networks);
+  },
+
+  shareActions: {
+    facebook(config) {
+      if (config.appId == null || !window.FB) {
+        openPopup('https://www.facebook.com/sharer/sharer.php', {
+          u: this.url()
+        });
+      } else {
+        window.FB.ui({
+          method:'feed',
+          name: this.title(),
+          link: this.url(),
+          picture: this.image(),
+          caption: this.caption(),
+          description: this.description()
+        });
+      }
+    },
+    twitter() {
+      openPopup('https://twitter.com/intent/tweet', {
+        text: this.description(),
+        url: this.url()
+      });
+    },
+    googlePlus() {
+      openPopup('https://plus.google.com/share', {
+        url: this.url()
+      });
+    },
+    pinterest() {
+      openPopup('https://www.pinterest.com/pin/create/button', {
+        url: this.url(),
+        media: this.image(),
+        description: this.description()
+      });
+    },
+    linkedin() {
+      openPopup('https://www.linkedin.com/shareArticle', {
+        mini: 'true',
+        url: this.url(),
+        title: this.title(),
+        summary: this.description()
+      });
+    },
+
+    email() {
+      openPopup('mailto:', {
+        subject: this.title(),
+        body: `${this.description()}\n${this.url()}`
+      });
+    },
+
+    reddit() {
+      openPopup('http://www.reddit.com/submit', {
+        url: this.url(),
+        title: this.title()
+      });
+    },
+
+    whatsapp() {
+      openPopup('whatsapp://send', {
+        text: `${this.description} ${this.url()}`
+      });
+    }
+  },
+
+  actions: {
+    share(network) {
+      let fn = this.shareActions[network.name];
+      if (fn) {
+        fn.call(this, network);
+      }
+    }
+  },
 
   didInsertElement() {
     this._super.apply(this, arguments);
 
-    let dynamicConfig = {
-      title: this._defaultTitle(),
-      image: this._defaultImage(),
-      description: this._defaultDescription()
-    };
-    let _config = _.merge({}, defaultConfig, this.get('config'), dynamicConfig);
-
-    this.set('shareConfig', _config);
-
-    // Disable whatsapp display if not a mobile device
-    if (_config.networks.whatsapp.enabled && !this._isMobile()) {
-      _config.networks.whatsapp.enabled = false;
-    }
-
-    // Default order of networks if no network order entered
-    if (_config.ui.networkOrder.length === 0) {
-      _config.ui.networkOrder = [
-        'pinterest',
-        'twitter',
-        'facebook',
-        'whatsapp',
-        'googlePlus',
-        'reddit',
-        'linkedin',
-        'email'
-      ];
-    }
-
-    for (let network of Object.keys(_config.networks)) {
-      if (_config.ui.networkOrder.indexOf(network.toString()) < 0) {
-        _config.networks[network].enabled = false;
-        _config.ui.networkOrder.push(network);
-      }
-    }
-
-    this._detectNetworks();
-    this._normalizeNetworkConfiguration();
-
-    // Inject Facebook JS SDK (if Facebook is enabled)
-    if (_config.networks.facebook.enabled && _config.networks.facebook.loadSdk) {
-      this._injectFacebookSdk();
-    }
-
-    //TODO: css hide the disabled networks
-
-    //let networksCon = this.$(`${_config.ui.namespace}social`)[0];
-    let networks = this.$('li');
-
-    //instance.addEventListener('click', () =>
-      //this._eventToggle(instance, networksCon)
-    //);
-
-    let mouseupNetworkListener = (name, network) => {
-      return () => {
-        this[`_network${capitalize(name)}`](network);
-      };
-    };
-
-    let hookListener = (when, name) => {
-      return () => {
-        this._hook(when, name);
-      };
-    };
-    // Add listener to activate networks and close button
-    networks.each((i, network) => {
-      let $network = $(network);
-
-      if (typeof(network) !== "undefined") {
-        let name = $network.attr('data-network');
-        let a = $network.find('a')[0];
-
-        $network.addClass(_config.networks[name].class);
-
-        a.addEventListener('mousedown', hookListener('before', name));
-        a.addEventListener('mouseup', mouseupNetworkListener(name, network));
-        a.addEventListener('click', hookListener('after', name));
-      }
-    });
-  },
-
-  _eventToggle(button, networks) {
-    if (this._hasClass(networks, 'active')) {
-      this._eventClose(networks);
-    } else {
-      this._eventOpen(button, networks);
+    let facebookConfig = this.get('networks').find(n => n.name === 'facebook');
+    if (facebookConfig && facebookConfig.appId != null) {
+      injectFacebookSdk(facebookConfig.appId);
     }
   },
 
-  _eventOpen(button, networks) {
-    if (this._hasClass(networks, 'load')) {
-      this._removeClass(networks, 'load');
-    }
-
-    this._addClass(networks, 'active');
+  url() {
+    return window.location.href;
   },
 
-  _eventClose(button) {
-    this._removeClass(button, 'active');
-  },
-
-  _eventListen(button, networks) {
-    let dimensions = this._getDimensions(button, networks);
-    if (this.listener === null) {
-      this.listener = window.setInterval(() =>
-        this._adjustClasses(button, networks, dimensions), 100
-      );
-    } else {
-      window.clearInterval(this.listener);
-      this.listener = null;
-    }
-  },
-
-  _networkFacebook(element) {
-    let config = this.get('shareConfig');
-
-    if (config.networks.facebook.loadSdk) {
-      if (!window.FB) {
-        console.error('The Facebook JS SDK hasn\'t loaded yet.');
-        return this._updateHref(element, 'https://www.facebook.com/sharer/sharer.php', {
-          u: config.networks.facebook.url
-        });
-      }
-      return window.FB.ui({
-        method:'feed',
-        name: config.networks.facebook.title,
-        link: config.networks.facebook.url,
-        picture: config.networks.facebook.image,
-        caption: config.networks.facebook.caption,
-        description: config.networks.facebook.description
-      });
-    } else {
-      return this._updateHref(
-        element,
-        'https://www.facebook.com/sharer/sharer.php', {
-          u: config.networks.facebook.url
-        }
-      );
-    }
-  },
-
-  _networkTwitter(element) {
-    let config = this.get('shareConfig');
-
-    this._updateHref(element, 'https://twitter.com/intent/tweet', {
-      text: config.networks.twitter.description,
-      url: config.networks.twitter.url
-    });
-  },
-
-  _networkGooglePlus(element) {
-    let config = this.get('shareConfig');
-
-    this._updateHref(element, 'https://plus.google.com/share', {
-      url: config.networks.googlePlus.url
-    });
-  },
-
-  _networkPinterest(element) {
-    let config = this.get('shareConfig');
-
-    this._updateHref(element, 'https://www.pinterest.com/pin/create/button', {
-      url: config.networks.pinterest.url,
-      media: config.networks.pinterest.image,
-      description: config.networks.pinterest.description
-    });
-  },
-
-  _networkLinkedin(element) {
-    let config = this.get('shareConfig');
-
-    this._updateHref(element, 'https://www.linkedin.com/shareArticle', {
-      mini: 'true',
-      url: config.networks.linkedin.url,
-      title: config.networks.linkedin.title,
-      summary: config.networks.linkedin.description
-    });
-  },
-
-  _networkEmail(element) {
-    let config = this.get('shareConfig');
-
-    this._updateHref(element, 'mailto:', {
-      subject: config.networks.email.title,
-      body: config.networks.email.description
-    });
-  },
-
-  _networkReddit(element) {
-    let config = this.get('shareConfig');
-
-    this._updateHref(element, 'http://www.reddit.com/submit', {
-      url: config.networks.reddit.url,
-      title: config.networks.reddit.title
-    });
-  },
-
-  _networkWhatsapp(element) {
-    let config = this.get('shareConfig');
-
-    this._updateHref(element, 'whatsapp://send', {
-      text: config.networks.whatsapp.description + " " +
-        config.networks.whatsapp.url
-    });
-  },
-
-  _injectFacebookSdk() {
-    let config = this.get('shareConfig');
-    let bodyTag = $(document).find('body')[0];
-
-    if (!window.FB && config.networks.facebook.appId &&
-        !bodyTag.querySelector('#fb-root')) {
-      let script = document.createElement('script');
-      script.text = `window.fbAsyncInit=function(){FB.init({appId:'${config.networks.facebook.appId}',status:true,xfbml:true})};(function(e,t,n){var r,i=e.getElementsByTagName(t)[0];if (e.getElementById(n)){return}r=e.createElement(t);r.id=n;r.src='//connect.facebook.net/en_US/all.js';i.parentNode.insertBefore(r,i)})(document,'script','facebook-jssdk');`;
-
-      let fbRoot = document.createElement('div');
-      fbRoot.id = 'fb-root';
-
-      bodyTag.appendChild(fbRoot);
-      bodyTag.appendChild(script);
-    }
-  },
-
-  _hook(type, network) {
-    let config = this.get('shareConfig');
-
-    let fn = config.networks[network][type];
-
-    if (typeof fn === 'function') {
-      let opts = fn.call(config.networks[network]);
-
-      if (opts !== undefined) {
-        opts = this._normalizeFilterConfigUpdates(opts);
-        this.extend(config.networks[network], opts, true);
-        this._normalizeNetworkConfiguration();
-      }
-    }
-  },
-
-  _defaultTitle() {
+  title() {
     let content;
     if ((content = (document.querySelector('meta[property="og:title"]') ||
                   document.querySelector('meta[name="twitter:title"]')))) {
@@ -265,7 +128,7 @@ export default Ember.Component.extend({
     }
   },
 
-  _defaultImage() {
+  image() {
     let content;
     if ((content = (document.querySelector('meta[property="og:image"]') ||
                     document.querySelector('meta[name="twitter:image"]')))) {
@@ -273,7 +136,10 @@ export default Ember.Component.extend({
     }
   },
 
-  _defaultDescription() {
+  caption() {
+  },
+
+  description() {
     let content;
     if ((content = (document.querySelector('meta[property="og:description"]') ||
                   document.querySelector('meta[name="twitter:description"]') ||
@@ -282,86 +148,53 @@ export default Ember.Component.extend({
     } else {
       return '';
     }
-  },
+  }
+});
 
-  _detectNetworks() {
-    const config = this.get('shareConfig');
+function expandNetworkConfig(entry) {
+  if (typeof entry === 'string') {
+    return { name: entry };
+  } else {
+    return entry;
+  }
+}
 
-    // Update network-specific configuration with global configurations
-    for (let network of Object.keys(config.networks)) {
-      for (let option of Object.keys(config.networks[network])) {
-        if (config.networks[network][option] === null) {
-          config.networks[network][option] = config[option];
-        }
-      }
+function injectFacebookSdk(appId) {
+  let bodyTag = $(document).find('body')[0];
 
-      // Check for enabled networks and display them
-      if (config.networks[network].enabled) {
-        this.class = 'enabled';
-        config.enabledNetworks += 1;
-      } else {
-        this.class = 'disabled';
-      }
+  if (!window.FB && !bodyTag.querySelector('#fb-root')) {
+    let script = document.createElement('script');
+    script.text = `window.fbAsyncInit=function(){FB.init({appId:'${appId}',status:true,xfbml:true})};(function(e,t,n){var r,i=e.getElementsByTagName(t)[0];if (e.getElementById(n)){return}r=e.createElement(t);r.id=n;r.src='//connect.facebook.net/en_US/all.js';i.parentNode.insertBefore(r,i)})(document,'script','facebook-jssdk');`;
 
-      config.networks[network].class = this.class;
-    }
-  },
+    let fbRoot = document.createElement('div');
+    fbRoot.id = 'fb-root';
 
-  _normalizeNetworkConfiguration() {
-    const config = this.get('shareConfig');
+    bodyTag.appendChild(fbRoot);
+    bodyTag.appendChild(script);
+  }
+}
 
-    // Don't load FB SDK if FB appId isn't present
-    if (!config.networks.facebook.appId) {
-      config.networks.facebook.loadSdk = false;
-    }
+function openPopup(target, params) {
 
-    // Encode Twitter description for URL
-    if (!!config.networks.twitter.description) {
-      if (!this._isEncoded(config.networks.twitter.description)) {
-        config.networks.twitter.description = encodeURIComponent(config.networks.twitter.description);
-      }
-    }
+  let qs = Object.keys(params)
+    .filter(k => params[k])
+    .map(k => `${k}=${toRFC3986(params[k])}`).join('&');
 
-    // Typecast Facebook appId to a String
-    if (typeof config.networks.facebook.appId === 'number') {
-      config.networks.facebook.appId = config.networks.facebook.appId.toString();
-    }
-  },
+  if (qs) {
+    target = `${target}?${qs}`;
+  }
 
-  _normalizeFilterConfigUpdates(opts) {
-    let config = this.get('shareConfig');
+  let popup = {
+    width: 500,
+    height: 350
+  };
 
-    if (config.networks.facebook.appId !== opts.appId) {
-      console.warn('You are unable to change the Facebook appId after the button has been initialized. Please update your Facebook filters accordingly.');
-      delete(opts.appId);
-    }
+  popup.top = (screen.height / 2) - (popup.height / 2);
+  popup.left = (screen.width / 2)  - (popup.width / 2);
 
-    if (config.networks.facebook.loadSdk !== opts.loadSdk) {
-      console.warn('You are unable to change the Facebook loadSdk option after the button has been initialized. Please update your Facebook filters accordingly.');
-      delete(opts.appId);
-    }
-
-    return opts;
-  },
-
-  _updateHref(element, url, params) {
-    let config = this.get('shareConfig');
-
-    let encode = url.indexOf('mailto:') >= 0;
-    let a = element.getElementsByTagName('a')[0];
-    a.setAttribute('href', this._getUrl(url, !encode, params));
-    if(!encode && (!config.networks.facebook.loadSdk || element.getAttribute('class') !== 'facebook')) {
-      let popup = {
-        width: 500,
-        height: 350
-      };
-
-      popup.top = (screen.height / 2) - (popup.height / 2);
-      popup.left = (screen.width / 2)  - (popup.width / 2);
-
-      window.open(
-        a.href,
-        'targetWindow', `
+  window.open(
+    target,
+    'targetWindow', `
           toolbar=no,
           location=no,
           status=no,
@@ -373,60 +206,11 @@ export default Ember.Component.extend({
           width=${popup.width},
           height=${popup.height}
         `
-      );
-    }
-  },
+  );
+}
 
-  _getUrl(url, encode=false, params={}) {
-    let qs = (() => {
-      let results = [];
-      for (let k of Object.keys(params)) {
-        let v = params[k];
-        results.push(`${k}=${this._encode(v)}`);
-      }
-      return results.join('&');
-    })();
-
-    if (qs) { qs = `?${qs}`; }
-
-    return url + qs;
-  },
-
-  _encode(str) {
-    if (typeof str === 'undefined' || str === null || this._isEncoded(str)) {
-      return encodeURIComponent(str);
-    } else {
-      return this.toRFC3986(str);
-    }
-  },
-
-  open() { this._public('Open'); },
-  close() { this._public('Close'); },
-  toggle() { this._public('Toggle'); },
-  toggleListen() { this._public('Listen'); },
-
-  _public(action) {
-    let config = this.get('shareConfig');
-
-    let networks =
-      this.$(`${config.ui.namespace}social`)[0];
-    this[`_event${action}`](networks);
-  },
-
-  _isMobile() {
-    return navigator.userAgent.match(/Android|iPhone|PhantomJS/i) &&
-           !navigator.userAgent.match(/iPod|iPad/i);
-  },
-
-  _isEncoded(str) {
-    str = this.toRFC3986(str);
-    return decodeURIComponent(str) !== str;
-  },
-
-  toRFC3986(s) {
-    let tmp = encodeURIComponent(s);
-    tmp.replace(/[!'()*]/g, function(c) {
-      return `%${c.charCodeAt(0).toString(16)}`;
-    });
-  }
-});
+function toRFC3986(s) {
+  return encodeURIComponent(s).replace(/[!'()*]/g, function(c) {
+    return `%${c.charCodeAt(0).toString(16)}`;
+  });
+}

--- a/addon/templates/components/share-buttons.hbs
+++ b/addon/templates/components/share-buttons.hbs
@@ -1,12 +1,3 @@
-<div class="sb-social load {{flyouts}} networks-{{enabledNetworks}}">
-  <ul>
-    <li onclick="return false;" class="pinterest" data-network="pinterest"><a></a></li>
-    <li onclick="return false;" class="twitter" data-network="twitter"><a></a></li>
-    <li onclick="return false;" class="facebook" data-network="facebook"><a></a></li>
-    <li onclick="return false;" class="whatsapp" data-network="whatsapp"><a></a></li>
-    <li onclick="return false;" class="googlePlus" data-network="googlePlus"><a></a></li>
-    <li onclick="return false;" class="reddit" data-network="reddit"><a></a></li>
-    <li onclick="return false;" class="linkedin" data-network="linkedin"><a></a></li>
-    <li class="email" data-network="email"><a></a></li>
-  </ul>
-</div>
+{{#each networks as |network|}}
+  <li class={{network.name}} ><a {{action "share" network}} ></a></li>
+{{/each}}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-lodash": "0.0.9",
     "ember-resolver": "^2.0.3",
     "ember-try": "~0.0.8"
   },

--- a/vendor/share-buttons.css
+++ b/vendor/share-buttons.css
@@ -1,182 +1,10 @@
-@import url("//fonts.googleapis.com/css?family=Lato");
-.share-buttons {
-  position: relative;
-  font-size: 16px;
-  color: #333;
-  background: #a29baa;
-  padding: 5px 10px 5px 1.75em;
-  border-radius: 5px;
-  font-family: Lato, sans-serif;
-  font-weight: 800;
-  -webkit-font-smoothing: antialiased;
-  cursor: pointer;
-  white-space: nowrap;
-  -webkit-transition: all .3s ease;
-          transition: all .3s ease;
-  text-transform: uppercase;
-}
-.share-buttons:hover {
-  color: rgba(51,51,51,0.8);
-  background: rgba(162,155,170,0.8);
-}
-.share-buttons:before {
-  position: absolute;
-  line-height: 1em;
-  left: 0.6em;
-  width: 1em;
-  height: 1em;
-  content: ' ';
-  background: url("/ember-share-buttons/images/svg/export.svg") no-repeat;
-}
-.share-buttons .sb-social {
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: all 0.4s ease;
-          transition: all 0.4s ease;
-}
-.share-buttons .sb-social.sb-center {
-  left: 50%;
-}
-.share-buttons .sb-social.sb-center.sb-top {
-  top: 0;
-  -webkit-transform: translate(-50%, -100%);
-      -ms-transform: translate(-50%, -100%);
-          transform: translate(-50%, -100%);
-}
-.share-buttons .sb-social.sb-center.sb-bottom {
-  bottom: 0;
-  -webkit-transform: translate(-50%, 100%);
-      -ms-transform: translate(-50%, 100%);
-          transform: translate(-50%, 100%);
-}
-.share-buttons .sb-social.sb-center.active.sb-top {
-  top: -1em;
-}
-.share-buttons .sb-social.sb-center.active.sb-bottom {
-  bottom: -1em;
-}
-.share-buttons .sb-social.sb-left {
-  left: 50%;
-}
-.share-buttons .sb-social.sb-left.sb-top {
-  top: 0;
-  -webkit-transform: translate(calc(-100% + 30px), -100%);
-      -ms-transform: translate(calc(-100% + 30px), -100%);
-          transform: translate(calc(-100% + 30px), -100%);
-}
-.share-buttons .sb-social.sb-left.sb-middle {
-  top: 50%;
-  left: 0;
-  -webkit-transform: translate(-100%, -50%);
-      -ms-transform: translate(-100%, -50%);
-          transform: translate(-100%, -50%);
-}
-.share-buttons .sb-social.sb-left.sb-bottom {
-  bottom: 0;
-  -webkit-transform: translate(calc(-100% + 30px), 100%);
-      -ms-transform: translate(calc(-100% + 30px), 100%);
-          transform: translate(calc(-100% + 30px), 100%);
-}
-.share-buttons .sb-social.sb-left.active.sb-top {
-  top: -1em;
-}
-.share-buttons .sb-social.sb-left.active.sb-middle {
-  left: -1em;
-}
-.share-buttons .sb-social.sb-left.active.sb-bottom {
-  bottom: -1em;
-}
-.share-buttons .sb-social.sb-right {
-  left: 50%;
-}
-.share-buttons .sb-social.sb-right.sb-top {
-  top: 0;
-  -webkit-transform: translate(-30px, -100%);
-      -ms-transform: translate(-30px, -100%);
-          transform: translate(-30px, -100%);
-}
-.share-buttons .sb-social.sb-right.sb-middle {
-  top: 50%;
-  left: 100%;
-  -webkit-transform: translate(0, -50%);
-      -ms-transform: translate(0, -50%);
-          transform: translate(0, -50%);
-}
-.share-buttons .sb-social.sb-right.sb-bottom {
-  bottom: 0;
-  -webkit-transform: translate(-30px, 100%);
-      -ms-transform: translate(-30px, 100%);
-          transform: translate(-30px, 100%);
-}
-.share-buttons .sb-social.sb-right.active.sb-top {
-  top: -1em;
-}
-.share-buttons .sb-social.sb-right.active.sb-middle {
-  left: calc(100% + 1em);
-}
-.share-buttons .sb-social.sb-right.active.sb-bottom {
-  bottom: -1em;
-}
-.share-buttons .sb-social.active {
-  opacity: 1;
-  -webkit-transition: all 0.4s ease;
-          transition: all 0.4s ease;
-  visibility: visible;
-}
-.share-buttons .sb-social.load {
-  -webkit-transition: none !important;
-          transition: none !important;
-}
-@media screen and (max-width: 400px) {
-  .share-buttons .sb-social.networks-6.sb-center {
-    white-space: initial;
-    text-align: center;
-    width: 300px;
-  }
-}
-@media screen and (max-width: 460px) {
-  .share-buttons .sb-social.networks-7.sb-center {
-    white-space: initial;
-    text-align: center;
-    width: 360px;
-  }
-}
-@media screen and (max-width: 400px) {
-  .share-buttons .sb-social.networks-7.sb-center {
-    white-space: initial;
-    text-align: center;
-    width: 300px;
-  }
-}
-@media screen and (max-width: 520px) {
-  .share-buttons .sb-social.networks-8.sb-center {
-    white-space: initial;
-    text-align: center;
-    width: 420px;
-  }
-}
-@media screen and (max-width: 460px) {
-  .share-buttons .sb-social.networks-8.sb-center {
-    white-space: initial;
-    text-align: center;
-    width: 360px;
-  }
-}
-@media screen and (max-width: 400px) {
-  .share-buttons .sb-social.networks-8.sb-center {
-    white-space: initial;
-    text-align: center;
-    width: 300px;
-  }
-}
-.share-buttons .sb-social ul {
+ul.share-buttons {
   margin: 0;
   padding: 0;
   list-style: none;
   line-height: 0;
 }
-.share-buttons .sb-social ul li {
+ul.share-buttons li {
   position: relative;
   height: 22px;
   width: 60px;
@@ -186,24 +14,12 @@
   font-size: 20px;
   cursor: pointer;
   z-index: 2;
+  display: inline-block;
   box-sizing: content-box;
   -webkit-transition: all .3s ease;
           transition: all .3s ease;
 }
-.share-buttons .sb-social ul li.enabled {
-  display: inline-block;
-}
-.share-buttons .sb-social ul li.disabled {
-  display: none;
-}
-.share-buttons .sb-social ul li:hover:before {
-  opacity: 0;
-}
-.share-buttons .sb-social ul li:hover:after {
-  opacity: 0.5;
-}
-.share-buttons .sb-social ul li:before,
-.share-buttons .sb-social ul li:after {
+.share-buttons li:before {
   content: ' ';
   position: absolute;
   width: inherit;
@@ -214,14 +30,12 @@
   -webkit-transition: all .3s ease;
           transition: all .3s ease;
   background-repeat: no-repeat !important;
-}
-.share-buttons .sb-social ul li:before {
   opacity: 1;
 }
-.share-buttons .sb-social ul li:after {
-  opacity: 0;
+.share-buttons li:hover:before {
+  opacity: 0.5;
 }
-.share-buttons .sb-social ul li a {
+.share-buttons li a {
   position: absolute;
   top: 0;
   left: 0;
@@ -229,75 +43,51 @@
   height: 100%;
   z-index: 3;
 }
-.share-buttons .sb-social li[class*='email'] {
+.share-buttons li[class*='email'] {
   background: #42c5b0;
 }
-.share-buttons .sb-social li[class*='email']:before {
+.share-buttons li[class*='email']:before {
   background-image: url("/ember-share-buttons/images/svg/email.svg");
 }
-.share-buttons .sb-social li[class*='email']:after {
-  background-image: url("/ember-share-buttons/images/svg/email.svg");
-}
-.share-buttons .sb-social li[class*='facebook'] {
+.share-buttons li[class*='facebook'] {
   background: #3b5998;
 }
-.share-buttons .sb-social li[class*='facebook']:before {
+.share-buttons li[class*='facebook']:before {
   background-image: url("/ember-share-buttons/images/svg/facebook.svg");
 }
-.share-buttons .sb-social li[class*='facebook']:after {
-  background-image: url("/ember-share-buttons/images/svg/facebook.svg");
-}
-.share-buttons .sb-social li[class*='googlePlus'] {
+.share-buttons li[class*='googlePlus'] {
   background: #e34429;
 }
-.share-buttons .sb-social li[class*='googlePlus']:before {
+.share-buttons li[class*='googlePlus']:before {
   background-image: url("/ember-share-buttons/images/svg/googlePlus.svg");
 }
-.share-buttons .sb-social li[class*='googlePlus']:after {
-  background-image: url("/ember-share-buttons/images/svg/googlePlus.svg");
-}
-.share-buttons .sb-social li[class*='linkedin'] {
+.share-buttons li[class*='linkedin'] {
   background: #4875b4;
 }
-.share-buttons .sb-social li[class*='linkedin']:before {
+.share-buttons li[class*='linkedin']:before {
   background-image: url("/ember-share-buttons/images/svg/linkedin.svg");
 }
-.share-buttons .sb-social li[class*='linkedin']:after {
-  background-image: url("/ember-share-buttons/images/svg/linkedin.svg");
-}
-.share-buttons .sb-social li[class*='pinterest'] {
+.share-buttons li[class*='pinterest'] {
   background: #c5282f;
 }
-.share-buttons .sb-social li[class*='pinterest']:before {
+.share-buttons li[class*='pinterest']:before {
   background-image: url("/ember-share-buttons/images/svg/pinterest.svg");
 }
-.share-buttons .sb-social li[class*='pinterest']:after {
-  background-image: url("/ember-share-buttons/images/svg/pinterest.svg");
-}
-.share-buttons .sb-social li[class*='reddit'] {
+.share-buttons li[class*='reddit'] {
   background: #a1caf2;
 }
-.share-buttons .sb-social li[class*='reddit']:before {
+.share-buttons li[class*='reddit']:before {
   background-image: url("/ember-share-buttons/images/svg/reddit.svg");
 }
-.share-buttons .sb-social li[class*='reddit']:after {
-  background-image: url("/ember-share-buttons/images/svg/reddit.svg");
-}
-.share-buttons .sb-social li[class*='twitter'] {
+.share-buttons li[class*='twitter'] {
   background: #6cdfea;
 }
-.share-buttons .sb-social li[class*='twitter']:before {
+.share-buttons li[class*='twitter']:before {
   background-image: url("/ember-share-buttons/images/svg/twitter.svg");
 }
-.share-buttons .sb-social li[class*='twitter']:after {
-  background-image: url("/ember-share-buttons/images/svg/twitter.svg");
-}
-.share-buttons .sb-social li[class*='whatsapp'] {
+.share-buttons li[class*='whatsapp'] {
   background: #4dc247;
 }
-.share-buttons .sb-social li[class*='whatsapp']:before {
-  background-image: url("/ember-share-buttons/images/svg/whatsapp.svg");
-}
-.share-buttons .sb-social li[class*='whatsapp']:after {
+.share-buttons li[class*='whatsapp']:before {
   background-image: url("/ember-share-buttons/images/svg/whatsapp.svg");
 }


### PR DESCRIPTION
This reimplments the buttons as idiomatic Ember, which has the key benefit of working on fastboot.

It also removes a lot of dubious configuration and layout management features left over from the original library that inspired this addon. The encoding functions were straight-up broken and useless.

Also, the email sharing was broken because it didn't include the URL being shared.
